### PR TITLE
No more submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "dist"]
-	path = dist
-	url = https://github.com/texastribune/newsapps-styles.git
-	branch = gh-pages


### PR DESCRIPTION
This blows away the old way of hosting the styleguide within the project with `gh-pages`. Should make things much more sane.