### PR TITLE
Bypass bourbon button mixin

### DIFF
--- a/_initialize.scss
+++ b/_initialize.scss
@@ -6,8 +6,8 @@
 @import 'helpers/colors';
 @import 'helpers/grid';
 @import 'helpers/typography';
-@import 'helpers/base';
 @import 'helpers/buttons';
+@import 'helpers/base';
 @import 'helpers/tables';
 
 @import 'theme/prose';

--- a/components/_banner.scss
+++ b/components/_banner.scss
@@ -1,4 +1,4 @@
-/* Basic Banner */
+// Basic Banner
 
 $banner-height: 600px;
 $grand-header-image-url: 'http://placekitten.com/1000/800';
@@ -34,8 +34,8 @@ $grand-header-image-url: 'http://placekitten.com/1000/800';
       font-size: 2em;
       font-weight: 800;
       line-height: 1.15;
-      text-shadow: $black 3px 3px 0;
       margin-bottom: .25em;
+      text-shadow: $black 3px 3px 0;
 
       @include media($default-desktop) {
         font-size: 3.5em;
@@ -49,8 +49,8 @@ $grand-header-image-url: 'http://placekitten.com/1000/800';
       font-size: 1em;
       letter-spacing: .0625em;
       line-height: 1.15;
+      margin-bottom: 1.5em;
       text-shadow: none;
-      margin-bottom: 1.5em;;
 
       @include media($default-desktop) {
         font-size: 1.5em;

--- a/helpers/_base.scss
+++ b/helpers/_base.scss
@@ -138,6 +138,6 @@ hr {
 
   input[type="submit"],
   input[type="button"] {
-    @include button($tribune-yellow);
+    @include btn($tribune-yellow);
   }
 }

--- a/helpers/_base.scss
+++ b/helpers/_base.scss
@@ -108,16 +108,17 @@ hr {
   form,
   select {
     display: inline-block;
+
     &.full-width {
       width: 100%;
     }
   }
 
   select,
-  input[type="text"],
-  input[type="radio"],
-  input[type="email"],
-  input[type="number"] {
+  [type="text"],
+  [type="radio"],
+  [type="email"],
+  [type="number"] {
     @extend %font-base;
     background: transparent;
     border: 1px solid $line-gray;
@@ -129,15 +130,15 @@ hr {
   }
 
   option,
-  input[type="text"],
-  input[type="radio"],
-  input[type="email"],
-  input[type="number"] {
+  [type="text"],
+  [type="radio"],
+  [type="email"],
+  [type="number"] {
     padding: .5em .25em;
   }
 
-  input[type="submit"],
-  input[type="button"] {
+  [type="submit"],
+  [type="button"] {
     @include btn($tribune-yellow);
   }
 }

--- a/helpers/_buttons.scss
+++ b/helpers/_buttons.scss
@@ -1,4 +1,6 @@
-@mixin button($color, $type: null) {
+// FIXME Once Bourbon v5 lands, its button mixin will longer be available. At
+// that time, we are free to change the name back.
+@mixin btn($color, $type: null) {
   @include clearfix;
   border-radius: 4px;
   cursor: pointer;
@@ -22,7 +24,7 @@
     } @else {
       color: $bodytext-black;
     }
-    border: 0px;
+    border: 0;
     padding: .5em .75em .625em;
   }
 
@@ -37,9 +39,9 @@
 }
 
 .button {
-  @include button($tribune-yellow);
+  @include btn($tribune-yellow);
 }
 
 .ghost-button {
-  @include button($teal, ghost);
+  @include btn($teal, ghost);
 }

--- a/helpers/_buttons.scss
+++ b/helpers/_buttons.scss
@@ -7,7 +7,7 @@
   display: inline-block;
   font-family: $base-sans-serif;
   letter-spacing: .03rem;
-  margin: 0 0 0.3em;
+  margin: 0 0 .3em;
   text-align: center;
   vertical-align: middle;
 
@@ -20,7 +20,7 @@
   } @else {
     background: $color;
     @if $color == $teal {
-     color: $white;
+      color: $white;
     } @else {
       color: $bodytext-black;
     }
@@ -31,7 +31,7 @@
   &:active,
   &:hover {
     @if $type == ghost {
-      background-color: transparentize($color, 0.95);
+      background-color: transparentize($color, .95);
     } @else {
       background-color: transparentize($color, .3);
     }

--- a/helpers/_grid.scss
+++ b/helpers/_grid.scss
@@ -25,20 +25,20 @@ $max-width: 1081px;
   @include pad(0 10px);
 }
 
-/* Grid Mixins */
-/* =========== */
+// Grid Mixins
+// ===========
 
 // Clearfix
 // --------
 // Ensure elements don't accidentally overlap.
 @mixin clearfix {
   &:after {
-   visibility: hidden;
-   display: block;
-   font-size: 0;
-   content: " ";
-   clear: both;
-   height: 0;
+    clear: both;
+    content: ' ';
+    display: block;
+    font-size: 0;
+    height: 0;
+    visibility: hidden;
  }
 }
 
@@ -48,7 +48,7 @@ $max-width: 1081px;
 // More info: http://www.joshfry.me/blog/2013/05/13/omega-reset-for-bourbon-neat/
 @mixin omega-reset($nth) {
   &:nth-child(#{$nth}) { margin-right: flex-gutter($grid-columns, $gutter); }
-  &:nth-child(#{$nth}+1) { clear: none }
+  &:nth-child(#{$nth}+1) { clear: none; }
 }
 
 // Features-Layout

--- a/helpers/_tables.scss
+++ b/helpers/_tables.scss
@@ -132,8 +132,8 @@ data-type="number": Add to <th> or <td> to ensure text aligns right
       @if $mobile-header-type == inline-block {
 
         &:before {
-          float: left;
           display: inline-block;
+          float: left;
           margin: 0 1em .25em 0;
           width: $mobile-header-width;
         }

--- a/theme/_graphic.scss
+++ b/theme/_graphic.scss
@@ -1,6 +1,6 @@
 .graphic {
-  @include clearfix;
   @extend %forms;
+  @include clearfix;
   line-height: 1.4;
   margin: 0 0 1.875em;
   // padding-bottom: 1em;
@@ -40,8 +40,8 @@
   }
 
   .footer {
-    @include clearfix;
     @extend %font-xs;
+    @include clearfix;
     background-color: $white;
     color: lighten($bodytext-black, 45%);
     font-family: $base-sans-serif;
@@ -56,6 +56,3 @@
   }
 
 }
-
-
-

--- a/theme/_prose.scss
+++ b/theme/_prose.scss
@@ -87,8 +87,8 @@ q.blockquote {
   font-family: $base-sans-serif;
   font-weight: 300;
   line-height: 1.3;
-  padding: 1em;
   margin-bottom: 1em;
+  padding: 1em;
 }
 
 .headline {
@@ -107,5 +107,3 @@ q.blockquote {
   margin: 0 0 1em;
   text-transform: uppercase;
 }
-
-


### PR DESCRIPTION
# Yay for alliteration

Changes the name of our button mixin to `btn` from `button`. We were clashing with Bourbon's own `button` mixin. They are removing it in `v5`, so we're free to change it back then. I added a note to `_button.scss` about it.

Also had to move `_button.scss` in front of `_base.scss` in the load change in `initialize.scss` so it has the mixin it needs.

I also did some code linting while I was in here, because my linter was quite grumpy.

Also - the changes in #17 are no longer needed with this.