### PR TITLE
swap utils/typography import

### DIFF
--- a/_init-helpers.scss
+++ b/_init-helpers.scss
@@ -1,5 +1,5 @@
 @import 'helpers/normalize';
 @import 'helpers/colors';
-@import 'helpers/typography';
 @import 'helpers/utils';
+@import 'helpers/typography';
 @import 'helpers/tables';


### PR DESCRIPTION
Calls import for  _utils.scss before _typography.scss to fix a dependency bug.
